### PR TITLE
コメントをにくきゅう文字にすること成功 #21

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -100,3 +100,6 @@ gem 'rails-i18n', '~> 7.0.0'
 
 #OGP 参考記事：https://zenn.dev/yoshiki105/articles/eb093bf603e728
 gem "meta-tags"
+
+#にくきゅう文字：https://rubygems.org/gems/pad_character
+gem "pad_character"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -232,6 +232,7 @@ GEM
       oauth2 (>= 1.4, < 3)
       omniauth (~> 2.0)
     orm_adapter (0.5.0)
+    pad_character (0.1.0)
     pg (1.5.3)
     pry (0.14.2)
       coderay (~> 1.1)
@@ -345,6 +346,7 @@ DEPENDENCIES
   kaminari
   meta-tags
   omniauth-google-oauth2
+  pad_character
   pg (~> 1.1)
   pry-byebug
   puma (~> 5.0)

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -4,7 +4,7 @@
     <%= image_tag 'logo_nikukyu.jpg', class: 'rounded-full h-12 w-12' %>
     <div id="js-comment-<%= comment.id %>">
       <div class="flex items-center justify-center text-center text-xl">
-        <%= simple_format(comment.body) %>
+        <%= simple_format(comment.body.to_pad) %>
       </div>
     </div>
     <% if current_user.own?(comment) %>


### PR DESCRIPTION
https://github.com/kashiwagi-rena/pad_characterを入れた
コメントに対応させた